### PR TITLE
Make test suite run without scipy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,50 +22,45 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install base dependencies
-      run: pip install numpy matplotlib pytest
+      run: pip install numpy matplotlib pytest pytest-subtests html5lib
 
     - name: Test minimums
-      run: pytest tests/test_basic.py
-
-    - name: Install test dependencies
-      if: ${{ !contains(matrix.python-version, 'pypy') }}  # no scipy wheels for pypy
-      run: pip install pytest numpy matplotlib pytest-subtests html5lib scipy
-
-    - name: Test only scipy
-      if: ${{ !contains(matrix.python-version, 'pypy') }}  # no scipy wheels for pypy
       run: pytest
 
+    - name: Install SciPy
+      # --only-binary disables compiling the package from source if a binary wheel is not available, such as PyPy
+      run: pip install --only-binary ":all:" scipy || true
+
     - name: Install python-graphblas
-      if: ${{ !contains(matrix.python-version, 'pypy') && matrix.python-version != '3.7' }}  # no wheels for pypy and old python
+      if: ${{ !contains(matrix.python-version, 'pypy') && matrix.python-version != '3.7' }}  # no wheels for PyPy or old Python
       run: |
         pip install suitesparse-graphblas==7.4.4.1a1
         pip install python-graphblas
 
     - name: Install pydata sparse
-      if: ${{ !contains(matrix.python-version, 'pypy') && matrix.python-version != '3.7' }}  # no wheels for pypy and old python
+      if: ${{ !contains(matrix.python-version, 'pypy') && matrix.python-version != '3.7' }}  # no wheels for PyPy or old Python
       run: |
         pip install sparse
 
     - name: Test without Jupyter
-      if: ${{ !contains(matrix.python-version, 'pypy') }}  # no scipy wheels for pypy
       run: pytest
 
     - name: Install Jupyter
-      if: ${{ !contains(matrix.python-version, 'pypy') }}  # no scipy wheels for pypy
+      if: ${{ !contains(matrix.python-version, 'pypy') }}
       run: pip install jupyter
 
     - name: Test with Jupyter
-      if: ${{ !contains(matrix.python-version, 'pypy') }}  # no scipy wheels for pypy
+      if: ${{ !contains(matrix.python-version, 'pypy') }}
       run: pytest
 
     - name: Test with Coverage
-      if: ${{ contains(matrix.os, 'ubuntu') && !contains(matrix.python-version, 'pypy') }}
+      if: ${{ contains(matrix.os, 'ubuntu') }}
       run: |
         pip install pytest-cov
         pytest --cov=matspy --cov-report term --cov-report=xml
 
     - name: Upload Coverage to Codecov
-      if: ${{ contains(matrix.os, 'ubuntu') && !contains(matrix.python-version, 'pypy') }}
+      if: ${{ contains(matrix.os, 'ubuntu') }}
       uses: codecov/codecov-action@v3
       with:
         gcov: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,4 @@ repository = "https://github.com/alugowski/matspy"
 
 [project.optional-dependencies]
 test = ["pytest", "scipy", "matplotlib", "html5lib", "matrepr"]
+testextra = ["python-graphblas", "sparse"]

--- a/tests/test_graphblas.py
+++ b/tests/test_graphblas.py
@@ -12,13 +12,11 @@ try:
 
     # Context initialization must happen before any other imports
     gb.init("suitesparse", blocking=True)
-
-    have_gb = True
 except ImportError:
-    have_gb = False
+    gb = None
 
 
-@unittest.skipIf(not have_gb, "python-graphblas not installed")
+@unittest.skipIf(gb is None, "python-graphblas not installed")
 class GraphBLASTests(unittest.TestCase):
     def setUp(self):
         self.mats = [

--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -5,12 +5,18 @@
 import unittest
 
 import numpy.random
-import scipy.sparse
+try:
+    import scipy
+    import scipy.sparse
+except ImportError:
+    scipy = None
+
 from matspy import to_spy_heatmap
 
 numpy.random.seed(123)
 
 
+@unittest.skipIf(scipy is None, "scipy not installed")
 class SpyHeatmapTests(unittest.TestCase):
     def test_buckets_1(self):
         density = 0.3

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -5,12 +5,17 @@
 import unittest
 
 import numpy as np
+try:
+    import scipy
+except ImportError:
+    scipy = None
 
 from matspy import spy_to_mpl, to_sparkline, to_spy_heatmap
 
 np.random.seed(123)
 
 
+@unittest.skipIf(scipy is None, "scipy not installed")  # scipy is used internally by numpy_impl
 class NumPyTests(unittest.TestCase):
     def setUp(self):
         self.mats = [

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -5,13 +5,18 @@
 import unittest
 
 import numpy.random
-import scipy.sparse
+try:
+    import scipy
+    import scipy.sparse
+except ImportError:
+    scipy = None
 
 from matspy import spy_to_mpl, to_sparkline
 
 numpy.random.seed(123)
 
 
+@unittest.skipIf(scipy is None, "scipy not installed")
 class SciPyTests(unittest.TestCase):
     def setUp(self):
         self.mats = [

--- a/tests/test_sparkline.py
+++ b/tests/test_sparkline.py
@@ -5,13 +5,18 @@
 import unittest
 
 import numpy.random
-import scipy.sparse
+try:
+    import scipy
+    import scipy.sparse
+except ImportError:
+    scipy = None
 
 from matspy import to_sparkline
 
 numpy.random.seed(123)
 
 
+@unittest.skipIf(scipy is None, "scipy not installed")
 class SparklineTests(unittest.TestCase):
     def test_small_buckets(self):
         for dims in [(1001, 1001), (11, 11)]:

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -10,14 +10,18 @@ except ImportError:
     sparse = None
 
 import numpy as np
-import scipy.sparse
+try:
+    import scipy
+    import scipy.sparse
+except ImportError:
+    scipy = None
 
 from matspy import spy_to_mpl, to_sparkline, to_spy_heatmap
 
 np.random.seed(123)
 
 
-@unittest.skipIf(sparse is None, "pydata/sparse not installed")
+@unittest.skipIf(sparse is None or scipy is None, "pydata/sparse not installed")
 class PyDataSparseTests(unittest.TestCase):
     def setUp(self):
         self.mats = [


### PR DESCRIPTION
Lack of scipy means nearly every test must be skipped, but this can make testing some environments easier.